### PR TITLE
To configure the Gateway in non-interactive mode

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if [[ ! -f "${STORJ_CONFIG_DIR}/config.yaml" ]]; then
-	./gateway setup
+	./gateway setup "$@"
 fi
 
 exec ./gateway run $RUN_PARAMS "$@"


### PR DESCRIPTION
It will make possible to configure the Gateway in non-interactive mode:
```
docker run -it --rm --mount type=bind,source=${PWD}/gateway,destination=/root/.local/share/storj/gateway/ --name gateway storjlabs/gateway:b8e4299-v1.1.0-go1.13.8 --non-interactive --server.address=":7777" --access 15....
```